### PR TITLE
Remove USA exclusive search param from geocode arcgis api call

### DIFF
--- a/server/scripts/index.mjs
+++ b/server/scripts/index.mjs
@@ -62,7 +62,6 @@ const init = () => {
 		paramName: 'text',
 		params: {
 			f: 'json',
-			countryCode: 'USA', // 'USA,PRI,VIR,GUM,ASM',
 			category,
 			maxSuggestions: 10,
 		},


### PR DESCRIPTION
The current goecoding acgis API call has a hardcoded parameter to limit all results to the USA. This removes that.